### PR TITLE
Update and rename diskstation.md to downloadstation.md

### DIFF
--- a/src/pages/en/services/downloadstation.md
+++ b/src/pages/en/services/downloadstation.md
@@ -1,6 +1,6 @@
 ---
-title: Synology Diskstation
-description: Synology Diskstation Widget Configuration
+title: Synology Download Station
+description: Synology Download Station Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 


### PR DESCRIPTION
Diskstation is fundamentally different from Download Station. Synology Diskstation Manager (DSM) is basically the OS of the NAS. Download Station is a web-based download application which allows you to download files from the Internet through BT, FTP, HTTP, NZB, FlashGet, QQDL, and eMule (See: https://kb.synology.com/en-af/DSM/help/DownloadStation/DownloadStation_desc?version=7).

I didn't touch the `widget type` because there are multiple references in the code and changing it will break the config for existing users.