### PR TITLE
refactor: add difference to glances and resource

### DIFF
--- a/src/pages/en/widgets/resources.md
+++ b/src/pages/en/widgets/resources.md
@@ -8,7 +8,7 @@ You can include all or some of the available resources. If you do not want to se
 
 The disk path is the path reported by `df` (Mounted On), or the mount point of the disk.
 
-The cpu and memory resource information are the container's usage while [glances](/en/widgets/glances) displays the host machine's usage.
+The cpu and memory resource information are the container's usage while [glances](/en/widgets/glances) displays statistics for the host machine on which it is installed.
 
 **Any disk you wish to access must be mounted to your container as a volume.**
 

--- a/src/pages/en/widgets/resources.md
+++ b/src/pages/en/widgets/resources.md
@@ -8,6 +8,8 @@ You can include all or some of the available resources. If you do not want to se
 
 The disk path is the path reported by `df` (Mounted On), or the mount point of the disk.
 
+The cpu and memory resource information are the container's usage while [glances](/en/widgets/glances) displays the host machine's usage.
+
 **Any disk you wish to access must be mounted to your container as a volume.**
 
 ```yaml


### PR DESCRIPTION
The key difference between glances and resource is not stated. For beginners, it's easy to assume that the cpu and memory is the host machines usage while glances does the same. But both widgets produces different usage info hence, the confusion. This PR solves this issue.

***Tested locally**