### PR TITLE
Fix spacing in service-widgets.mdx example code.

### DIFF
--- a/src/pages/en/configs/service-widgets.mdx
+++ b/src/pages/en/configs/service-widgets.mdx
@@ -33,13 +33,13 @@ Each widget can optionally provide a list of which fields should be visible via 
 
 ```yaml
 - Sonarr:
-  icon: sonarr.png
-  href: http://sonarr.host.or.ip
-  widget:
-      type: sonarr
-      fields: ["wanted", "queued"]
-      url: http://sonarr.host.or.ip
-      key: apikeyapikeyapikeyapikeyapikey
+      icon: sonarr.png
+      href: http://sonarr.host.or.ip
+      widget:
+          type: sonarr
+          fields: ["wanted", "queued"]
+          url: http://sonarr.host.or.ip
+          key: apikeyapikeyapikeyapikeyapikey
 ```
 
 ## Available Widgets


### PR DESCRIPTION
 Updated the second example code block to be consistent with the first, and to prevent syntax errors.