### PR TITLE
Added ghostfolio widget documentation

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -132,11 +132,11 @@ export const SIDEBAR: Sidebar = {
             ]},
             { text: 'Information Providers', links: [
                 { text: 'Coin Market Cap', link: 'en/services/coin-market-cap' },
-                { text: 'Ghostfolio', link: 'en/services/ghostfolio'},
                 { text: 'Mastodon', link: 'en/services/mastodon' },
             ]},
             { text: 'Other', links: [
                 { text: 'Fileflows', link: 'en/services/fileflows' },
+                { text: 'Ghostfolio', link: 'en/services/ghostfolio'},
                 { text: 'Grafana', link: 'en/services/grafana' },
                 { text: 'Homebridge', link: 'en/services/homebridge' },
                 { text: 'Kopia', link: 'en/services/kopia' },

--- a/src/config.ts
+++ b/src/config.ts
@@ -132,6 +132,7 @@ export const SIDEBAR: Sidebar = {
             ]},
             { text: 'Information Providers', links: [
                 { text: 'Coin Market Cap', link: 'en/services/coin-market-cap' },
+                { text: 'Ghostfolio', link: 'en/services/ghostfolio'},
                 { text: 'Mastodon', link: 'en/services/mastodon' },
             ]},
             { text: 'Other', links: [

--- a/src/pages/en/services/ghostfolio.md
+++ b/src/pages/en/services/ghostfolio.md
@@ -3,14 +3,16 @@ title: Ghostfolio
 description: Ghostfolio Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
-Authentication requires manually obtaining a Bearer token; use `http://<ghostfolio_host>:<ghostfolio_port>/api/v1/auth/anonymous/<INSERT_SECURITY_TOKEN_OF_ACCOUNT>` to do this.
-Note that the Bearer token is valid for 6 months, after which a new one must be generated.
 
-Allowed fields: `["gross_percent_today", "gross_percent_ytd", "gross_percent_1y", "gross_percent_max"]`
+Authentication requires manually obtaining a Bearer token which can be obtained by visiting `http://<ghostfolio_host>:<ghostfolio_port>/api/v1/auth/anonymous/<SECURITY_TOKEN_OF_ACCOUNT>`.
+
+*Note that the Bearer token is valid for 6 months, after which a new one must be generated.*
+
+Allowed fields: `["gross_percent_today", "gross_percent_1y", "gross_percent_max"]`
 
 ```yaml
 widget:
     type: ghostfolio
     url: http://ghostfoliohost:port
-    key: ghostfoliobearerkey
+    key: ghostfoliobearertoken
 ```

--- a/src/pages/en/services/ghostfolio.md
+++ b/src/pages/en/services/ghostfolio.md
@@ -1,0 +1,16 @@
+---
+title: Ghostfolio
+description: Ghostfolio Widget Configuration
+layout: ../../../layouts/MainLayout.astro
+---
+Authentication requires manually obtaining a Bearer token; use `http://<ghostfolio_host>:<ghostfolio_port>/api/v1/auth/anonymous/<INSERT_SECURITY_TOKEN_OF_ACCOUNT>` to do this.
+Note that the Bearer token is valid for 6 months, after which a new one must be generated.
+
+Allowed fields: `["gross_percent_today", "gross_percent_ytd", "gross_percent_1y", "gross_percent_max"]`
+
+```yaml
+widget:
+    type: ghostfolio
+    url: http://ghostfoliohost:port
+    key: ghostfoliobearerkey
+```


### PR DESCRIPTION
I'm unsure if "Information Providers" is the correct category for this tool, but since the others in there were _kind of related_, I thought it would be okay. Otherwise I suppose the "Other" category is the best fit?

https://github.com/benphelps/homepage/pull/1071