### PR TITLE
Improve & correct the opnsense widget documentation

### DIFF
--- a/src/pages/en/services/opnsense.md
+++ b/src/pages/en/services/opnsense.md
@@ -4,16 +4,16 @@ description: OPNSense Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 
-API key / secret can be generated via the admin, see [the opnsense docs](https://docs.opnsense.org/development/how-tos/api.html#creating-keys).
+The API key & secret can be generated via the webui, by creating a new user at `System/Access/Users` called `homepage-api`, ensuring `Generate a scrambled password to prevent local database logins for this user.` is checked, and then edit the effective privileges selecting `Diagnostics: System Activity` & `Status: Traffic Graph` only.  Finally, create a new API key which will download an `apikey.txt` file with your key and secret in it.  Paste the contents following the = symbol in both lines to the username and password fields below.
 
-Allowed fields: `["uptime", "cpu", "memory", "wanUpload", "wanDownload"]`.
+Allowed fields: `["cpu", "memory", "wanUpload", "wanDownload"]`.
 
 ```yaml
 widget:
     type: opnsense
     url: http://opnsense.host.or.ip
-    username: apikey
-    password: apisecret
+    username: key
+    password: secret
 ```
 
 *Added in v0.5.6*

--- a/src/pages/en/services/opnsense.md
+++ b/src/pages/en/services/opnsense.md
@@ -4,7 +4,12 @@ description: OPNSense Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 
-The API key & secret can be generated via the webui, by creating a new user at `System/Access/Users` called `homepage-api`, ensuring `Generate a scrambled password to prevent local database logins for this user.` is checked, and then edit the effective privileges selecting `Diagnostics: System Activity` & `Status: Traffic Graph` only.  Finally, create a new API key which will download an `apikey.txt` file with your key and secret in it.  Paste the contents following the = symbol in both lines to the username and password fields below.
+The API key & secret can be generated via the webui by creating a new user at _System/Access/Users_. Ensure "Generate a scrambled password to prevent local database logins for this user" is checked and then edit the effective privileges selecting **only**:
+
+-  Diagnostics: System Activity
+-  Status: Traffic Graph
+
+Finally, create a new API key which will download an `apikey.txt` file with your key and secret in it. Use the values as the username and password fields, respectively, in your homepage config.
 
 Allowed fields: `["cpu", "memory", "wanUpload", "wanDownload"]`.
 


### PR DESCRIPTION
@shamoon I wonder if I might open this up for discussion again? After seeing the discussion on the [previous PR regarding the opnsense documentation.](https://github.com/benphelps/homepage-docs/pull/17)

Following the linked docs leaves people potentially creating an api key for their root user on opnsense with more permissions than homepage requires.  (Don't worry my root user is not able to login to the webui, I disabled it) 

It's not documented in the homepage docs what access the api requires for the widget to be functional.  I had to enable the widget, analyse the error messages and then give it permissions based on what the error messages were.  (Not difficult, but I'm not completely new to the opnsense API stuff either)

Whilst I do understand the need for succinct documentation, this PR is certainly no more lengthy than the current documentation for [proxmox](https://github.com/benphelps/homepage-docs/blob/main/src/pages/en/services/proxmox.md).

I certainly don't want to tread on @jhollowe toes here, but my version is a little shorter, I'd already forked and written it before I thought to check if anything had been done before and came upon the previous PR by @jhollowe and I don't mind if you reopen his PR in preference to mine, but I do think it would be beneficial to flesh out the docs a little bit when it comes down to API access to a firewall.

Also, I don't believe the `uptime` field is functional and I've removed that from the docs.   [Reference](https://github.com/benphelps/homepage/blob/main/src/widgets/opnsense/component.jsx#L23-L26)
