### PR TITLE
DOCS: Traefik IngressRoute documentation

### DIFF
--- a/src/pages/en/configs/kubernetes.md
+++ b/src/pages/en/configs/kubernetes.md
@@ -98,8 +98,8 @@ When the Kubernetes cluster connection has been properly configured, this servic
 Homepage can also read ingresses defined using the Traefik IngressRoute custom resource definition. Due to the complex nature of Traefik routing rules, it is required for the `gethomepage.dev/href` annotation to be set:
 
 ```yaml
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
 metadata:
   name: emby
   annotations:
@@ -113,17 +113,19 @@ metadata:
     gethomepage.dev/widget.url: "https://emby.example.com"
     gethomepage.dev/podSelector: ""
 spec:
-  rules:
-    - host: emby.example.com
-      http:
-        paths:
-          - backend:
-              service:
-                name: emby
-                port:
-                  number: 8080
-            path: /
-            pathType: Prefix
+  entryPoints:
+    - websecure
+  routes:
+  - kind: Rule
+    match: Host(`emby.example.com`)
+    services:
+    - kind: Service
+      name: emby
+      namespace: emby
+      port: 8080
+      scheme: http
+      strategy: RoundRobin
+      weight: 10
 ```
 
 If the `href` attribute is not present, Homepage will ignore the specific IngressRoute.

--- a/src/pages/en/configs/kubernetes.md
+++ b/src/pages/en/configs/kubernetes.md
@@ -8,8 +8,7 @@ The Kubernetes connectivity has the following requirements:
 
 * Kubernetes 1.19+
 * Metrics Service
-* An 
-controller
+* An Ingress controller
 
 The Kubernetes connection is configured in the `kubernetes.yaml` file. There are 3 modes to choose from:
 

--- a/src/pages/en/configs/kubernetes.md
+++ b/src/pages/en/configs/kubernetes.md
@@ -8,7 +8,8 @@ The Kubernetes connectivity has the following requirements:
 
 * Kubernetes 1.19+
 * Metrics Service
-* An Ingress controller
+* An 
+controller
 
 The Kubernetes connection is configured in the `kubernetes.yaml` file. There are 3 modes to choose from:
 
@@ -92,6 +93,41 @@ spec:
 ```
 
 When the Kubernetes cluster connection has been properly configured, this service will be automatically discovered and added to your Homepage.  **You do not need to specify the `namespace` or `app` values, as they will be automatically inferred.**
+
+### Traefik IngressRoute support
+
+Homepage can also read ingresses defined using the Traefik IngressRoute custom resource definition. Due to the complex nature of Traefik routing rules, it is required for the `gethomepage.dev/href` annotation to be set:
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: emby
+  annotations:
+    gethomepage.dev/href: "https://emby.example.com"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/description: Media Server
+    gethomepage.dev/group: Media
+    gethomepage.dev/icon: emby.png
+    gethomepage.dev/name: Emby
+    gethomepage.dev/widget.type: "emby"
+    gethomepage.dev/widget.url: "https://emby.example.com"
+    gethomepage.dev/podSelector: ""
+spec:
+  rules:
+    - host: emby.example.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: emby
+                port:
+                  number: 8080
+            path: /
+            pathType: Prefix
+```
+
+If the `href` attribute is not present, Homepage will ignore the specific IngressRoute.
 
 ## Caveats
 


### PR DESCRIPTION
This is the supporting documentation for this PR: https://github.com/benphelps/homepage/pull/1112 - "Feature: Add Traefik IngressRoute support for Kubernetes"