### PR TITLE
Update location of app password in nextcloud

### DIFF
--- a/src/pages/en/services/nextcloud.md
+++ b/src/pages/en/services/nextcloud.md
@@ -4,7 +4,7 @@ description: Nextcloud Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 
-Find your API key under `Settings > General`.
+Create an app password under `Settings > Personal > Security > Devices & sessions`.
 
 Allowed fields: `["cpuload", "memoryusage", "freespace", "activeusers"]`.
 


### PR DESCRIPTION
To use the widget you need an app password which is found here:

I think this doc originally just had the path copied from one of the *arr apps

![security image](https://cdn.jackbailey.dev/uploads/pLrad.png)
![app password](https://cdn.jackbailey.dev/uploads/XUIyi.png)