### PR TITLE
Update proxmox.md

### DIFF
--- a/src/pages/en/services/proxmox.md
+++ b/src/pages/en/services/proxmox.md
@@ -17,7 +17,7 @@ You will need to generate an API Token for new or an existing user. Here is an e
     - Path: /
     - Group: group from bullet 4 above
     - Role: PVEAuditor
-    - Propagate: Checked
+    - Propagate: UnChecked
 7. Expand Permissions, click on Users
 8. Click the Add button
     - User name: something informative like `api`


### PR DESCRIPTION
Setting needs to be unchecked to allow api to read values and display it on the service widget.

If left checked the widget returns 0 for VMS and LXC and NaN% for CPU and MEM.

Tested against proxmox version 7.4-3