### PR TITLE
Add documentation for Simple Icons and iconStyle

### DIFF
--- a/src/pages/en/configs/services.md
+++ b/src/pages/en/configs/services.md
@@ -64,7 +64,12 @@ Services may have descriptions,
 
 ## Icons
 
-Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/walkxcode/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png`. You can also specify icons from [material design icons](https://materialdesignicons.com) with `mdi-XX`. If you would like to load a remote icon, you may pass the URL to it. If you would like to load a local icon, first create a Docker mount to `/app/public/icons` and then reference your icon as `/icons/myicon.png`.
+Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/walkxcode/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png`.
+You can also specify prefixed icons from [material design icons](https://materialdesignicons.com) with `mdi-XX` or [simple icons](https://simpleicons.org/) with `si-XX`.
+If you would like to load a remote icon, you may pass the URL to it.
+If you would like to load a local icon, first create a Docker mount to `/app/public/icons` and then reference your icon as `/icons/myicon.png`.
+
+*Note: Material design icons for **brands** are being deprecated and may become unavailable in the future. It is recommended to source brand icons from simple icons.*
 
 ```yaml
 - Group A:

--- a/src/pages/en/configs/services.md
+++ b/src/pages/en/configs/services.md
@@ -65,11 +65,14 @@ Services may have descriptions,
 ## Icons
 
 Services may have an icon attached to them, you can use icons from [Dashboard Icons](https://github.com/walkxcode/dashboard-icons) automatically, by passing the name of the icon, with, or without `.png`.
-You can also specify prefixed icons from [material design icons](https://materialdesignicons.com) with `mdi-XX` or [simple icons](https://simpleicons.org/) with `si-XX`.
-If you would like to load a remote icon, you may pass the URL to it.
-If you would like to load a local icon, first create a Docker mount to `/app/public/icons` and then reference your icon as `/icons/myicon.png`.
 
-*Note: Material design icons for **brands** are being deprecated and may become unavailable in the future. It is recommended to source brand icons from simple icons.*
+You can also specify prefixed icons from [Material Design Icons](https://materialdesignicons.com) with `mdi-XX` or [Simple Icons](https://simpleicons.org/) with `si-XX`.
+
+To use a remote icon, use the absolute URL (e.g. `https://...`).
+
+To use a local icon, first create a Docker mount to `/app/public/icons` and then reference your icon as `/icons/myicon.png`.
+
+*Note: Material Design Icons for **brands** were deprecated and may be removed in the future. Using Simple Icons for brand icons will prevent any issues if / when the Material Design Icons are removed.*
 
 ```yaml
 - Group A:

--- a/src/pages/en/configs/settings.md
+++ b/src/pages/en/configs/settings.md
@@ -124,6 +124,16 @@ You can also add an icon to a category under the `layout` setting similar to the
   ...
 ```
 
+### Icon Style
+
+You can specify that prefixed icons (ex: `icon: mdi-XXXX`) match your theme.
+More information about prefixed icons can be found in [options for service icons](/en/configs/services/#icons).
+
+```yaml
+iconStyle: theme # default to gradient
+
+```
+
 ### Five Columns
 
 You can add a fifth column (when `style: columns` which is default) by adding:

--- a/src/pages/en/configs/settings.md
+++ b/src/pages/en/configs/settings.md
@@ -126,12 +126,11 @@ You can also add an icon to a category under the `layout` setting similar to the
 
 ### Icon Style
 
-You can specify that prefixed icons (ex: `icon: mdi-XXXX`) match your theme.
+The default style for icons (e.g. `icon: mdi-XXXX`) is a gradient, or you can specify that prefixed icons match your theme with a 'flat' style using the setting below.
 More information about prefixed icons can be found in [options for service icons](/en/configs/services/#icons).
 
 ```yaml
-iconStyle: theme # default to gradient
-
+iconStyle: theme # optional, defaults to gradient
 ```
 
 ### Five Columns


### PR DESCRIPTION
This PR adds documentation for https://github.com/benphelps/homepage/pull/1438

Not sure what else to say about it. I did break up the very long line in `services.md` otherwise any suggestions to help make it conform to the docs are welcome.