### PR TITLE
Add docs for Changedetection.io widget

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -137,7 +137,7 @@ export const SIDEBAR: Sidebar = {
                 { text: 'Mastodon', link: 'en/services/mastodon' },
             ]},
             { text: 'Other', links: [
-                { text: 'ChangeDetection.io', link: 'en/services/changedetectionio'}
+                { text: 'Changedetection.io', link: 'en/services/changedetectionio'}
                 { text: 'Fileflows', link: 'en/services/fileflows' },
                 { text: 'FreshRSS', link: 'en/services/freshrss' },
                 { text: 'Ghostfolio', link: 'en/services/ghostfolio'},

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,6 +137,7 @@ export const SIDEBAR: Sidebar = {
                 { text: 'Mastodon', link: 'en/services/mastodon' },
             ]},
             { text: 'Other', links: [
+                { text: 'ChangeDetection.io', link: 'en/services/changedetectionio'}
                 { text: 'Fileflows', link: 'en/services/fileflows' },
                 { text: 'FreshRSS', link: 'en/services/freshrss' },
                 { text: 'Ghostfolio', link: 'en/services/ghostfolio'},

--- a/src/config.ts
+++ b/src/config.ts
@@ -137,7 +137,7 @@ export const SIDEBAR: Sidebar = {
                 { text: 'Mastodon', link: 'en/services/mastodon' },
             ]},
             { text: 'Other', links: [
-                { text: 'Changedetection.io', link: 'en/services/changedetectionio'}
+                { text: 'Changedetection.io', link: 'en/services/changedetectionio'},
                 { text: 'Fileflows', link: 'en/services/fileflows' },
                 { text: 'FreshRSS', link: 'en/services/freshrss' },
                 { text: 'Ghostfolio', link: 'en/services/ghostfolio'},

--- a/src/pages/en/services/changedetectionio.md
+++ b/src/pages/en/services/changedetectionio.md
@@ -9,7 +9,7 @@ Find your API key under `Settings > API`.
 ```yaml
 widget:
     type: changedetectionio
-    url: http://192.168.1.55:5000
+    url: http://changedetection.host.or.ip:port
     key: apikeyapikeyapikeyapikeyapikey
 ```
 

--- a/src/pages/en/services/changedetectionio.md
+++ b/src/pages/en/services/changedetectionio.md
@@ -1,0 +1,16 @@
+---
+title: ChangeDetection.io
+description: ChaneDetection.io Widget Configuration
+layout: ../../../layouts/MainLayout.astro
+---
+
+Find your API key under `Settings > API`.
+
+```yaml
+widget:
+    type: changedetectionio
+    url: http://192.168.1.55:5000
+    key: apikeyapikeyapikeyapikeyapikey
+```
+
+*Added in v0.5.1*

--- a/src/pages/en/services/changedetectionio.md
+++ b/src/pages/en/services/changedetectionio.md
@@ -1,6 +1,6 @@
 ---
 title: ChangeDetection.io
-description: ChaneDetection.io Widget Configuration
+description: ChangeDetection.io Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 

--- a/src/pages/en/services/changedetectionio.md
+++ b/src/pages/en/services/changedetectionio.md
@@ -1,6 +1,6 @@
 ---
-title: ChangeDetection.io
-description: ChangeDetection.io Widget Configuration
+title: Changedetection.io
+description: Changedetection.io Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 


### PR DESCRIPTION
Adds docs for the Changedetection.io widget added in Homepage 0.5.1
Details for the widget can be found at [benphelps/homepage#386](https://github.com/benphelps/homepage/pull/386)