### PR TITLE
Update service-widgets.mdx

### DIFF
--- a/src/pages/en/configs/service-widgets.mdx
+++ b/src/pages/en/configs/service-widgets.mdx
@@ -17,11 +17,11 @@ Using Emby as an example, this is how you would attach the Emby service widget.
 ```yaml
 - Emby:
       icon: emby.png
-      href: http://emby.home/
+      href: http://emby.host.or.ip/
       description: Movies & TV Shows
       widget:
           type: emby
-          url: http://emby.home/
+          url: http://emby.host.or.ip
           key: apikeyapikeyapikeyapikeyapikey
 ```
 


### PR DESCRIPTION
Removed trailing `/` in Emby widget example URL, and changed both URLs to match the Sonarr example block below as well as the format used in https://gethomepage.dev/en/services/emby/