### PR TITLE
Add documentation for sonarr/radarr queue

### DIFF
--- a/src/pages/en/services/radarr.md
+++ b/src/pages/en/services/radarr.md
@@ -6,13 +6,14 @@ layout: ../../../layouts/MainLayout.astro
 
 Find your API key under `Settings > General`.
 
-Allowed fields: `["wanted", "missing", "queued", "movies"]`.
+Allowed fields: `["wanted", "missing", "queued", "movies", "queue"]`. The queue is disabled by default, but can be enabled with the `enableQueue` option.
 
 ```yaml
 widget:
     type: radarr
     url: http://radarr.host.or.ip
     key: apikeyapikeyapikeyapikeyapikey
+    enableQueue: true # optional, defaults to false
 ```
 
 *Added in v0.1.0*

--- a/src/pages/en/services/radarr.md
+++ b/src/pages/en/services/radarr.md
@@ -6,7 +6,9 @@ layout: ../../../layouts/MainLayout.astro
 
 Find your API key under `Settings > General`.
 
-Allowed fields: `["wanted", "missing", "queued", "movies", "queue"]`. The queue is disabled by default, but can be enabled with the `enableQueue` option.
+Allowed fields: `["wanted", "missing", "queued", "movies"]`. 
+
+A detailed queue listing is disabled by default, but can be enabled with the `enableQueue` option.
 
 ```yaml
 widget:

--- a/src/pages/en/services/radarr.md
+++ b/src/pages/en/services/radarr.md
@@ -6,7 +6,7 @@ layout: ../../../layouts/MainLayout.astro
 
 Find your API key under `Settings > General`.
 
-Allowed fields: `["wanted", "missing", "queued", "movies"]`. 
+Allowed fields: `["wanted", "queued", "series"]`. 
 
 A detailed queue listing is disabled by default, but can be enabled with the `enableQueue` option.
 

--- a/src/pages/en/services/sonarr.md
+++ b/src/pages/en/services/sonarr.md
@@ -6,13 +6,14 @@ layout: ../../../layouts/MainLayout.astro
 
 Find your API key under `Settings > General`.
 
-Allowed fields: `["wanted", "queued", "series"]`.
+Allowed fields: `["wanted", "queued", "series", "queue"]`. The queue is disabled by default, but can be enabled with the `enableQueue` option.
 
 ```yaml
 widget:
     type: sonarr
     url: http://sonarr.host.or.ip
     key: apikeyapikeyapikeyapikeyapikey
+    enableQueue: true # optional, defaults to false
 ```
 
 *Added in v0.1.0*

--- a/src/pages/en/services/sonarr.md
+++ b/src/pages/en/services/sonarr.md
@@ -6,7 +6,9 @@ layout: ../../../layouts/MainLayout.astro
 
 Find your API key under `Settings > General`.
 
-Allowed fields: `["wanted", "queued", "series", "queue"]`. The queue is disabled by default, but can be enabled with the `enableQueue` option.
+Allowed fields: `["wanted", "missing", "queued", "movies"]`. 
+
+A detailed queue listing is disabled by default, but can be enabled with the `enableQueue` option.
 
 ```yaml
 widget:


### PR DESCRIPTION
This is a extension to the documentation for the sonarr and radarr queue requested from [this](https://github.com/benphelps/homepage/pull/1560) pull request