### PR TITLE
Fix link location

### DIFF
--- a/src/pages/en/widgets/glances.md
+++ b/src/pages/en/widgets/glances.md
@@ -4,7 +4,7 @@ description: Glances Information Widget Configuration
 layout: ../../../layouts/MainLayout.astro
 ---
 
-_(Find the Glances service widget [here](/en/widgets/glances/))_
+_(Find the Glances service widget [here](/en/services/glances/))_
 
 The Glances widget allows you to monitor the resources (CPU, memory, storage, temp & uptime) of host or another machine, and is designed to match the `resources` info widget. You can have multiple instances by adding another configuration block. The `cputemp`, `uptime` & `disk` states require separate API calls and thus are not enabled by default. Glances needs to be running in "web server" mode to enable the API, see the [glances docs](https://glances.readthedocs.io/en/latest/quickstart.html#web-server-mode).
 


### PR DESCRIPTION
Changed the link location to /en/services/glances/ as the information widget page currently refers to itself.