### PR TITLE
Add UDM-Pro instructions

### DIFF
--- a/src/pages/en/services/unifi-controller.md
+++ b/src/pages/en/services/unifi-controller.md
@@ -19,4 +19,14 @@ widget:
     site: Site Name # optional
 ```
 
+NOTE: If you're querying a Unifi Dream Machine Pro, then your `url` needs to have `/proxy/network` appended to it and most likely doesn't need the port specified either (port 8443 doesn't even respond on some newer firmwares). An example UDM-Pro widget would look like this:
+```yaml
+widget:
+    type: unifi
+    url: https://unifi.host.or.ip/proxy/network
+    username: username
+    password: password
+    site: Site Name # optional
+```
+
 *Added in v0.4.18, updated in 0.6.7*


### PR DESCRIPTION
Added an example config for pulling stats on a v3+ firmware UDM-Pro as the default one does not work as-is.